### PR TITLE
sr520-28 | Fix bottom cards on Construction Project pages

### DIFF
--- a/public/css/stylesheet-override2.css
+++ b/public/css/stylesheet-override2.css
@@ -2020,7 +2020,7 @@ div.flickr-carousel {
 
 .bottom-btn:hover {
   display: inline-block;
-  background-color: #1d3b1e;
+  background-color: #005151;
   color: #fff;
-  border-bottom: 1px solid #007b5f;
+  border-bottom: 1px solid #005151;
 }

--- a/views/i5-connection-project.ejs
+++ b/views/i5-connection-project.ejs
@@ -311,10 +311,11 @@
           </section>
 
         </div>
-        <!-- ###  CARD sidebar ### -->
+
         <div class="col-xl-4">
           <%- include('partials/horizontal-cards') %>
         </div>
+        
       </div>
     </main>
 

--- a/views/i5-connection-project.ejs
+++ b/views/i5-connection-project.ejs
@@ -280,45 +280,43 @@
               </div>
             </div>
           </div>
+
+          <section class="flickr-area gx-5" style="background-color: white;">
+            <div class="container">
+              <div class="flickr-container">
+                <p></p>
+                <p></p>
+                <h2 class="flickr-header fw-700">Construction photos</h2>
+                <div class="flickr-carousel" style="border: 1px solid white;">
+                  <a
+                    data-flickr-embed="true"
+                    data-footer="true"
+                    href="https://www.flickr.com/photos/wsdot/albums/72157720017909938"
+                    title="SR 520 - I-5 Express Lanes Connection Project"
+                    target="_blank"
+                    ><img
+                      src="https://live.staticflickr.com/65535/53108615152_ead2434a2b_h.jpg"
+                      width="1400px"
+                      height="100%;"
+                      alt="SR 520 - I-5 Express Lanes Connection Project"
+                  /></a>
+                  <script
+                    async
+                    src="//embedr.flickr.com/assets/client-code.js"
+                    charset="utf-8"
+                  ></script>
+                </div>
+              </div>
+            </div>
+          </section>
+
         </div>
         <!-- ###  CARD sidebar ### -->
         <div class="col-xl-4">
-          <%- include('partials/sidebar-cards') %>
+          <%- include('partials/horizontal-cards') %>
         </div>
       </div>
     </main>
-
-    <section class="flickr-area gx-5">
-      <div class="container">
-        <div class="flickr-container">
-          <p></p>
-          <p></p>
-          <h2 class="flickr-header fw-700">Construction photos</h2>
-          <div class="flickr-carousel">
-            <a
-              data-flickr-embed="true"
-              data-footer="true"
-              href="https://www.flickr.com/photos/wsdot/albums/72157720017909938"
-              title="SR 520 - I-5 Express Lanes Connection Project"
-              target="_blank"
-              ><img
-                src="https://live.staticflickr.com/65535/53108615152_ead2434a2b_h.jpg"
-                width="1400px"
-                height="100%;"
-                alt="SR 520 - I-5 Express Lanes Connection Project"
-            /></a>
-            <script
-              async
-              src="//embedr.flickr.com/assets/client-code.js"
-              charset="utf-8"
-            ></script>
-          </div>
-          <p></p>
-          <p></p>
-          <p></p>
-        </div>
-      </div>
-    </section>
 
     <!-- ###  FOOTER ###  -->
 

--- a/views/montlake-project.ejs
+++ b/views/montlake-project.ejs
@@ -132,13 +132,25 @@
                              </div>
                         </div>
                       </div>
-                    </div>
-   
 
-                    <!-- ###  CARD sidebar ### -->
+                      <section class="flickr-area gx-5" style="background-color: white;">
+                        <div class="container"> 
+                          <div class="flickr-container">
+                            <p></p> 
+                            <p></p>
+                            <h2 class="flickr-header fw-700">Construction photos</h2>
+                            <div class="flickr-carousel" style="border: 1px solid white;">
+                              <a data-flickr-embed="true" data-footer="true" href="https://www.flickr.com/photos/wsdot/sets/72157718536569452/" title="SR 520 - Montlake Connection Project" target="_blank"><img src="https://live.staticflickr.com/65535/53173240036_1fd90a7b7c_h.jpg" width="1400px" height="100%;" alt="SR 520 - Montlake Connection Project"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+                            </div>
+                          </div>
+                        </div>
+                      </section>
+
+                    </div>
+
                     <div class="col-xl-4">
                                           
-                      <%- include('partials/sidebar-cards') %>
+                      <%- include('partials/horizontal-cards') %>
 
                     </div>
 
@@ -147,24 +159,6 @@
               </div>
         
         </main>
-  
-        <section class="flickr-area gx-5" >
-
-          <div class="container"> 
-          <div class="flickr-container">
-            <p></p> 
-            <p></p>
-            <h2 class="flickr-header fw-700">Construction photos</h2>
-            <div class="flickr-carousel">
-              <a data-flickr-embed="true" data-footer="true" href="https://www.flickr.com/photos/wsdot/sets/72157718536569452/" title="SR 520 - Montlake Connection Project" target="_blank"><img src="https://live.staticflickr.com/65535/53173240036_1fd90a7b7c_h.jpg" width="1400px" height="100%;" alt="SR 520 - Montlake Connection Project"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
-            </div>
-            <p></p>
-            <p></p>
-            <p></p>
-
-          </div>
-          </div>
-          </section>
 
 <!-- ###  FOOTER ###  -->
 

--- a/views/portage-bay-project.ejs
+++ b/views/portage-bay-project.ejs
@@ -123,53 +123,47 @@
   
                           </div>
                         </div>
+
+                        <section class="flickr-area gx-5" style="background-color: white;">
+                          <div class="container">
+                            <div class="flickr-container">
+                              <p></p>
+                              <p></p>
+                              <h2 class="flickr-header fw-700">Construction photos</h2>
+                              <div class="flickr-carousel" style="border: 1px solid white;">
+                                <a
+                                  data-flickr-embed="true"
+                                  data-footer="true"
+                                  href="https://www.flickr.com/photos/wsdot/albums/72177720312695382"
+                                  title="SR 520 - Portage Bay Bridge and Roanoke Lid Project"
+                                  target="_blank"
+                                  ><img
+                                    src="https://live.staticflickr.com/65535/53108615152_ead2434a2b_h.jpg"
+                                    width="1400px"
+                                    height="100%;"
+                                    alt="SR 520 - Portage Bay Bridge and Roanoke Lid Project"
+                                /></a>
+                                <script
+                                  async
+                                  src="//embedr.flickr.com/assets/client-code.js"
+                                  charset="utf-8"
+                                ></script>
+                              </div>
+                            </div>
+                          </div>
+                        </section>
   
                       </div>
-                      <!-- ###  CARD sidebar ### -->
-                      <div class="col-xl-4">
-                        
-                        <%- include('partials/sidebar-cards') %>
-
+       
+                      <div class="col-xl-4"> 
+                        <%- include('partials/horizontal-cards') %>
                       </div>
-
 
                   </div>
                 </div>
               </div>
         
         </main>
-
-        <section class="flickr-area gx-5">
-          <div class="container">
-            <div class="flickr-container">
-              <p></p>
-              <p></p>
-              <h2 class="flickr-header fw-700">Construction photos</h2>
-              <div class="flickr-carousel">
-                <a
-                  data-flickr-embed="true"
-                  data-footer="true"
-                  href="https://www.flickr.com/photos/wsdot/albums/72177720312695382"
-                  title="SR 520 - Portage Bay Bridge and Roanoke Lid Project"
-                  target="_blank"
-                  ><img
-                    src="https://live.staticflickr.com/65535/53108615152_ead2434a2b_h.jpg"
-                    width="1400px"
-                    height="100%;"
-                    alt="SR 520 - Portage Bay Bridge and Roanoke Lid Project"
-                /></a>
-                <script
-                  async
-                  src="//embedr.flickr.com/assets/client-code.js"
-                  charset="utf-8"
-                ></script>
-              </div>
-              <p></p>
-              <p></p>
-              <p></p>
-            </div>
-          </div>
-        </section>
 
 <!-- ###  FOOTER ###  -->
 


### PR DESCRIPTION
- Replace side-bar cards with horizontal cards
- Move flickr carousel above cards
- Change background from gray to white

Attempted to adjust the border radius of the flickr carousel to match the rest of the page stying but that does not appear to be possible. 