### PR TITLE
sr520-37 | Remove "Post online" and "remove online" fields from dashboard

### DIFF
--- a/views/projectForm.ejs
+++ b/views/projectForm.ejs
@@ -264,16 +264,6 @@ type="text/css" />
     </div>
 
     <div class="mb-3">
-        <label for="postDate" class="form-label">Post online on:</label>
-        <input type="date" class="form-control" id="postDate" name="postDate" required>
-    </div>
-
-    <div class="mb-3">
-        <label for="removeDate" class="form-label">Remove post on:</label>
-        <input type="date" class="form-control" id="removeDate" name="removeDate">
-    </div>
-
-    <div class="mb-3">
         <label for="contact" class="form-label">Contact</label>
         <select class="form-select" id="contact" name="contact">
             <option value="montlake">Montlake contact, 206-775-8885</option>


### PR DESCRIPTION
Removed "post online" and "remove online" from dashboard. 

After:
![Monosnap SR 520 Construction | Construction Entry Form 2023-12-11 11-30-16](https://github.com/ihateerrors/520-staging-express/assets/41652141/095eadbd-8a44-4ad2-a2cf-54267aeb4041)
